### PR TITLE
NAS-124783 / 24.04 / update openssl to 3.0.11 to try and fix build

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 PACKAGE="openssl"
 PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
-VERSION=3.0.9
+VERSION=3.0.11
 REVISION=1
 
 


### PR DESCRIPTION
apt servers for dragonfish were recently updated to pull in latest upstream packages. Now openzfs won't build because it's saying the openssl package will be DOWNGRADED
```
The following packages will be DOWNGRADED:
  libssl3 openssl
0 upgraded, 72 newly installed, 2 downgraded, 1 to remove and 0 not upgraded.
E: Packages were downgraded and -y was used without --allow-downgrades.
'openzfs' package failed to build: CallError('Command (\'chroot ./tmp/dpkg-overlay_openzfs /bin/bash -c "cd dpkg-src && apt install -y ./*.deb"\',) returned exit code 100 (Failed install build deps)')
```

Bump it here to see if that fixes the issue