### PR TITLE
NAS-125172 / 23.10.1 / bump to 3.0.12-2 (by yocalebo)

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 PACKAGE="openssl"
 PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
-VERSION=3.0.9
-REVISION=1
+VERSION=3.0.12
+REVISION=2
 
 
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION.debian.tar.xz


### PR DESCRIPTION
Pulls in fixes for CVE-2023-5363

Original PR: https://github.com/truenas/openssl/pull/3
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125172