### PR TITLE
NAS-125897 / 23.10.2 / Fix openssl build (by sonicaj)

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,13 +1,14 @@
 #!/bin/bash -ex
 PACKAGE="openssl"
 PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
-VERSION=3.0.12
-REVISION=2
+VERSION=3.0.11
+REVISION=1
+DEBIAN_SUFFIX='~deb12u2'
 
 
-wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION.debian.tar.xz
-tar xf ${PACKAGE}_$VERSION-$REVISION.debian.tar.xz
-rm ${PACKAGE}_$VERSION-$REVISION.debian.tar.xz
+wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz
+tar xf ${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz
+rm ${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz
 
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION.orig.tar.gz
 tar xf ${PACKAGE}_$VERSION.orig.tar.gz --strip 1


### PR DESCRIPTION
This commit adds changes to specify debian suffix so we can pull latest stable version of openssl available from upstream. Earlier specified version is not available on upstream mirrors and going through history - it was bumped to fix a CVE which has been fixed in the version specified in this commit (https://www.debian.org/security/2023/dsa-5532.en.html).

Original PR: https://github.com/truenas/openssl/pull/5
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125897