### PR TITLE
NAS-129828 / 24.04.2 / bump from 3.0.11-1~deb12u2 -> 3.0.13-1~deb12u1 (by yocalebo)

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 PACKAGE="openssl"
 PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
-VERSION=3.0.11
+VERSION=3.0.13
 REVISION=1
-DEBIAN_SUFFIX='~deb12u2'
+DEBIAN_SUFFIX='~deb12u1'
 
 
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz


### PR DESCRIPTION
For CVE-2024-6387, openssh requires libssl3 >= 3.0.13. This bumps to the latest version upstream debian provides.

Original PR: https://github.com/truenas/openssl/pull/8
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129828