### PR TITLE
NAS-131233 / 25.04 / Use FIPS 3.0.9 with OpenSSL 3.0.14

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -27,11 +27,10 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '/^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/tmp\/usr\/include\/$(DEB_HOST_MULTIARCH)\/openssl\//a\
-\
+sed -i '/^override_dh_installchangelogs/i \
 \t# install our custom FIPs data\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -27,10 +27,11 @@ make -j$(nproc)
 
 cd ..
 
+# inject our custom FIPS module/config. This places it above the override_dh_installchangelogs (the end of override_dh_auto_install-arch)
 sed -i '/^override_dh_installchangelogs/i \
-\t# install our custom FIPs data\
+\t# install our custom FIPS provider\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n$(MAKE) -C tests\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -38,3 +38,4 @@ sed -i '0,/^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/t
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules
+echo "usr/lib/ssl/fipsmodule.cnf" >> debian/openssl.install

--- a/pull.sh
+++ b/pull.sh
@@ -27,16 +27,11 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '/$(MAKE) -C build_shared all/a\
-\t# Install our custom FIPS provider\
-\tcp CUSTOMFIPS/providers/fips.so providers/\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/\
-\tfor build_dir in build_* ; do \\\
-\t\t[ -d "$$build_dir" ] && cp providers/fips.so providers/fipsmodule.cnf "$$build_dir/providers/" ; \\\
-\tdone' debian/rules
-
-
-sed -i 's/Configure shared/Configure shared --with-fips-provider=.\/providers\/fips.so/' debian/rules
+sed -i '/^\s*\$(MAKE) -C build_shared all/a\
+\
+\t# install our custom fips.so\
+\tcp CUSTOMFIPS/providers/fips.so build_shared/providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_shared/providers/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -31,7 +31,7 @@ cd ..
 sed -i '/^override_dh_installchangelogs/i \
 \t# install our custom FIPS provider\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) tests\n' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) test\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -27,12 +27,14 @@ make -j$(nproc)
 
 cd ..
 
+sed -i '0,/^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/tmp\/usr\/include\/$(DEB_HOST_MULTIARCH)\/openssl\//! {
+    /^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/tmp\/usr\/include\/$(DEB_HOST_MULTIARCH)\/openssl\//a\
+\
+\t# install our custom fips.so\
+\tcp CUSTOMFIPS/providers/fips.so build_shared/providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_shared/providers/fipsmodule.cnf
+}' debian/rules
 
-sed -i '/override_dh_auto_install-arch:/a\
-\tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\
-\tcp -f CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/\
-\tcp -f CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/etc/ssl/' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules
-echo "usr/lib/ssl/fipsmodule.cnf" >> debian/openssl.install

--- a/pull.sh
+++ b/pull.sh
@@ -31,8 +31,8 @@ sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 \
 # install our custom fips.so\
 override_dh_auto_build:\
-    cp CUSTOMFIPS/providers/fips.so providers/fips.so\
-    cp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
+\tcp CUSTOMFIPS/providers/fips.so providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -39,3 +39,4 @@ sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules
+echo "usr/lib/ssl/fipsmodule.cnf" >> debian/openssl.install

--- a/pull.sh
+++ b/pull.sh
@@ -31,8 +31,8 @@ sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 \
 # install our custom fips.so\
 override_dh_auto_build:\
-cp CUSTOMFIPS/providers/fips.so providers/fips.so\
-cp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
+    cp CUSTOMFIPS/providers/fips.so providers/fips.so\
+    cp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -27,10 +27,6 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '/override_dh_auto_configure:/a\
-\tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\
-\tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/etc/ssl/' debian/rules
 
 sed -i '/override_dh_auto_install-arch:/a\
 \tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\

--- a/pull.sh
+++ b/pull.sh
@@ -31,7 +31,7 @@ cd ..
 sed -i '/^override_dh_installchangelogs/i \
 \t# install our custom FIPS provider\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) -C . test\n' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -27,15 +27,20 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '/^\s*\$(MAKE) -C build_shared all/a\
-\
-\t# install our custom fips.so\
-\t# I am unsure if we use the build_shared or build_static, pretty sure shared.\
-\t# Just to be safe I moved it to both.\
-\tcp CUSTOMFIPS/providers/fips.so build_static/providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_static/providers/fipsmodule.cnf\
-\tcp CUSTOMFIPS/providers/fips.so build_shared/providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_shared/providers/fipsmodule.cnf' debian/rules
+# Add custom FIPS installation to override_dh_auto_configure
+sed -i '/override_dh_auto_configure:/a\
+\tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\
+\tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/etc/ssl/' debian/rules
+
+# Remove the previous custom FIPS installation from override_dh_auto_build-arch and override_dh_auto_build-indep
+sed -i '/# install our custom fips.so/,/cp CUSTOMFIPS\/providers\/fipsmodule.cnf build_shared\/providers\/fipsmodule.cnf/d' debian/rules
+
+# Add custom FIPS installation to override_dh_auto_install-arch
+sed -i '/override_dh_auto_install-arch:/a\
+\tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\
+\tcp -f CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/\
+\tcp -f CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/etc/ssl/' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -30,9 +30,12 @@ cd ..
 sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 \
 \t# install our custom fips.so\
-\tcp CUSTOMFIPS/providers/fips.so providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
+\t# I am unsure if we use the build_shared or build_static, pretty sure shared.\
+\t# Just to be safe I moved it to both.\
+\tcp CUSTOMFIPS/providers/fips.so build_static/providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_static/providers/fipsmodule.cnf\
+\tcp CUSTOMFIPS/providers/fips.so build_shared/providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_shared/providers/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules
-echo "usr/lib/ssl/fipsmodule.cnf" >> debian/openssl.install

--- a/pull.sh
+++ b/pull.sh
@@ -31,7 +31,7 @@ cd ..
 sed -i '/^override_dh_installchangelogs/i \
 \t# install our custom FIPS provider\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) test\n' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) -C . test\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -28,6 +28,7 @@ make -j$(nproc)
 cd ..
 
 sed -i '/^\s*\$(MAKE) -C build_shared all/a\
+\
 # install our custom fips.so\
 override_dh_auto_build:\
 cp CUSTOMFIPS/providers/fips.so providers/fips.so\

--- a/pull.sh
+++ b/pull.sh
@@ -31,7 +31,7 @@ cd ..
 sed -i '/^override_dh_installchangelogs/i \
 \t# install our custom FIPS provider\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n$(MAKE) -C tests\n' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) -C tests\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -27,8 +27,7 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '/^\s*\mv debian/tmp/usr/include/openssl/configuration.h debian/tmp/usr/include/$(DEB_HOST_MULTIARCH)/openssl/
-/a\
+sed -i '/^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/tmp\/usr\/include\/$(DEB_HOST_MULTIARCH)\/openssl\//a\
 \
 \t# install our custom FIPs data\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\

--- a/pull.sh
+++ b/pull.sh
@@ -31,7 +31,7 @@ cd ..
 sed -i '/^override_dh_installchangelogs/i \
 \t# install our custom FIPS provider\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) -C tests\n' debian/rules
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf\n\t$(MAKE) tests\n' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -4,6 +4,7 @@ PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
 VERSION=3.0.14
 REVISION=1
 DEBIAN_SUFFIX='~deb12u2'
+FIPS_VERSION=3.0.9
 
 
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz
@@ -13,6 +14,18 @@ rm ${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION.orig.tar.gz
 tar xf ${PACKAGE}_$VERSION.orig.tar.gz --strip 1
 rm ${PACKAGE}_$VERSION.orig.tar.gz
+
+mkdir CUSTOMFIPS
+cd CUSTOMFIPS
+wget https://www.openssl.org/source/openssl-${FIPS_VERSION}.tar.gz
+tar xf openssl-${FIPS_VERSION}.tar.gz
+rm openssl-${FIPS_VERSION}.tar.gz
+cd openssl-${FIPS_VERSION}
+./Configure enable-fips
+make -j$(nproc)
+
+cp providers/fips.so ../../providers
+cd ../..
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules
 echo "usr/lib/ssl/fipsmodule.cnf" >> debian/openssl.install

--- a/pull.sh
+++ b/pull.sh
@@ -27,11 +27,12 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '/^\s*\$(MAKE) -C build_shared all/a\
+sed -i '/^\s*\mv debian/tmp/usr/include/openssl/configuration.h debian/tmp/usr/include/$(DEB_HOST_MULTIARCH)/openssl/
+/a\
 \
 \t# install our custom FIPs data\
-\tcp CUSTOMFIPS/providers/fips.so providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
+\tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/usr/lib/ssl/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -25,6 +25,8 @@ rm -rf openssl-${FIPS_VERSION}
 ./Configure enable-fips
 make -j$(nproc)
 
+cd ..
+
 sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 # install our custom fips.so\
 override_dh_auto_build:\

--- a/pull.sh
+++ b/pull.sh
@@ -29,8 +29,7 @@ cd ..
 
 sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 \
-# install our custom fips.so\
-override_dh_auto_build:\
+\t# install our custom fips.so\
 \tcp CUSTOMFIPS/providers/fips.so providers/fips.so\
 \tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
 

--- a/pull.sh
+++ b/pull.sh
@@ -4,7 +4,7 @@ PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
 VERSION=3.0.14
 REVISION=1
 DEBIAN_SUFFIX='~deb12u2'
-FIPS_VERSION=3.0.9
+FIPS_VERSION=3.0.9 #Most recent validated FIPS (https://openssl-library.org/source/)
 
 
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz

--- a/pull.sh
+++ b/pull.sh
@@ -27,16 +27,11 @@ make -j$(nproc)
 
 cd ..
 
-# Add custom FIPS installation to override_dh_auto_configure
 sed -i '/override_dh_auto_configure:/a\
 \tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\
 \tcp CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/\
 \tcp CUSTOMFIPS/providers/fipsmodule.cnf debian/tmp/etc/ssl/' debian/rules
 
-# Remove the previous custom FIPS installation from override_dh_auto_build-arch and override_dh_auto_build-indep
-sed -i '/# install our custom fips.so/,/cp CUSTOMFIPS\/providers\/fipsmodule.cnf build_shared\/providers\/fipsmodule.cnf/d' debian/rules
-
-# Add custom FIPS installation to override_dh_auto_install-arch
 sed -i '/override_dh_auto_install-arch:/a\
 \tmkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules\
 \tcp -f CUSTOMFIPS/providers/fips.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/\

--- a/pull.sh
+++ b/pull.sh
@@ -29,9 +29,9 @@ cd ..
 
 sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 \
-\t# install our custom fips.so\
-\tcp CUSTOMFIPS/providers/fips.so build_shared/providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_shared/providers/fipsmodule.cnf' debian/rules
+\t# install our custom FIPs data\
+\tcp CUSTOMFIPS/providers/fips.so /providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf /providers/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -27,14 +27,16 @@ make -j$(nproc)
 
 cd ..
 
-sed -i '0,/^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/tmp\/usr\/include\/$(DEB_HOST_MULTIARCH)\/openssl\//! {
-    /^\s*\mv debian\/tmp\/usr\/include\/openssl\/configuration.h debian\/tmp\/usr\/include\/$(DEB_HOST_MULTIARCH)\/openssl\//a\
-\
-\t# install our custom fips.so\
-\tcp CUSTOMFIPS/providers/fips.so build_shared/providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf build_shared/providers/fipsmodule.cnf
-}' debian/rules
+sed -i '/$(MAKE) -C build_shared all/a\
+\t# Install our custom FIPS provider\
+\tcp CUSTOMFIPS/providers/fips.so providers/\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/\
+\tfor build_dir in build_* ; do \\\
+\t\t[ -d "$$build_dir" ] && cp providers/fips.so providers/fipsmodule.cnf "$$build_dir/providers/" ; \\\
+\tdone' debian/rules
 
+
+sed -i 's/Configure shared/Configure shared --with-fips-provider=.\/providers\/fips.so/' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -4,8 +4,9 @@ PACKAGE_FIRST_CHAR=$(printf "%s" "$PACKAGE" | cut -c1)
 VERSION=3.0.14
 REVISION=1
 DEBIAN_SUFFIX='~deb12u2'
-FIPS_VERSION=3.0.9 #Most recent validated FIPS (https://openssl-library.org/source/)
 
+#Most recent validated FIPS (https://openssl-library.org/source/)
+FIPS_VERSION=3.0.9
 
 wget http://deb.debian.org/debian/pool/main/$PACKAGE_FIRST_CHAR/$PACKAGE/${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz
 tar xf ${PACKAGE}_$VERSION-$REVISION$DEBIAN_SUFFIX.debian.tar.xz

--- a/pull.sh
+++ b/pull.sh
@@ -30,8 +30,8 @@ cd ..
 sed -i '/^\s*\$(MAKE) -C build_shared all/a\
 \
 \t# install our custom FIPs data\
-\tcp CUSTOMFIPS/providers/fips.so /providers/fips.so\
-\tcp CUSTOMFIPS/providers/fipsmodule.cnf /providers/fipsmodule.cnf' debian/rules
+\tcp CUSTOMFIPS/providers/fips.so providers/fips.so\
+\tcp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
 
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules

--- a/pull.sh
+++ b/pull.sh
@@ -20,12 +20,17 @@ cd CUSTOMFIPS
 wget https://www.openssl.org/source/openssl-${FIPS_VERSION}.tar.gz
 tar xf openssl-${FIPS_VERSION}.tar.gz
 rm openssl-${FIPS_VERSION}.tar.gz
-cd openssl-${FIPS_VERSION}
+mv openssl-${FIPS_VERSION}/* .
+rm -rf openssl-${FIPS_VERSION}
 ./Configure enable-fips
 make -j$(nproc)
 
-cp providers/fips.so ../../providers
-cd ../..
+sed -i '/^\s*\$(MAKE) -C build_shared all/a\
+# install our custom fips.so\
+override_dh_auto_build:\
+cp CUSTOMFIPS/providers/fips.so providers/fips.so\
+cp CUSTOMFIPS/providers/fipsmodule.cnf providers/fipsmodule.cnf' debian/rules
+
 
 sed -i '/CONFARGS *=/ s/$/ enable-fips/' debian/rules
 echo "usr/lib/ssl/fipsmodule.cnf" >> debian/openssl.install


### PR DESCRIPTION
FIPS 3.0.9 is the most recent validated FIPS module. For federal compliance, we want to use the most recent version of OpenSSL with the latest approved FIPS. 

These changes download and build FIPS 3.0.9, then modifies the OpenSSL 3.0.14 debian/rules file to have it copy the FIPS module and config over the existing one. 
During the build process of 3.0.9, it runs through a test suite to verify the module integrity.

The method of replacing the module is followed as outlined in their [official documentation](https://github.com/openssl/openssl/blob/master/README-FIPS.md) (adapting to this specific environment where it's replaced during the normal build process)


There is also a [middleware PR](https://github.com/truenas/middleware/pull/14629) with new tests to verify this change.